### PR TITLE
Update README.md with MetalLB project

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Generally, projects listed in the [CNCF Landscape](https://l.cncf.io) under the 
 - Istio
 - Kuma
 - Linkerd
+- MetalLB
 - NATS
 - Network Service Mesh
 


### PR DESCRIPTION
MetalLB is a network load balancer for Kubernetes and a CNCF sandbox project - adding to list of TAG Network in-scope projects