### PR TITLE
Fix mailing list join link and other broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Clarify and further concepts of cloud native networking, traffic management and 
 
 # Governance and Operations
 
-This TAG follows the [standard operating model](https://github.com/cncf/toc/blob/master/tags/cncf-sigs.md#operating-model) provided by the TOC unless otherwise stated here.
+This TAG follows the [standard operating model](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#operating-model) provided by the TOC unless otherwise stated here.
 
 # Operating Model
 
@@ -105,7 +105,7 @@ This TAG follows the [standard operating model](https://github.com/cncf/toc/blob
 - TOC Liaison: Duffie Cooley, Ricardo Rocha
 - Chairs: [Lee Calcote](https://twitter.com/lcalcote), [Lin Sun](https://twitter.com/linsun_unc), [Zack Butcher](https://github.com/ZackButcher) 
 
-In accordance with the [elections and terms](https://github.com/cncf/toc/blob/master/tags/cncf-sigs.md#elections) follow the [CNCF TAG definition](https://github.com/cncf/toc/blob/master/tags/cncf-sigs.md#elections).
+In accordance with the [elections and terms](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#elections) follow the [governance](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#governance).
 
 ## Communications
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ In accordance with the [elections and terms](https://github.com/cncf/toc/blob/ma
 ## Communications
 
 - Slack Channel ([#tag-network](https://app.slack.com/client/T08PSQ7BQ/CMG237Z5Z))
-- Join [TAG-Network](mailto:tag-network@lists.cncf.io) mailer at [lists.cncf.io](https://lists.cncf.io)
+- Join [TAG-Network](https://lists.cncf.io/g/cncf-tag-network/) mailing list at [lists.cncf.io](https://lists.cncf.io)
 - Repo: [https://github.com/cncf/tag-network](https://github.com/cncf/tag-network)
 - Meetings: 
   - Time: Network TAG meets the 2nd and 4th Thursday of every month at 9am Pacific (here's [a link](https://goo.gl/eyutah) to a public Google calendar that you can subscribe to).


### PR DESCRIPTION
Fixing that mailing list join link is opening an email to the mailing list and not the mailing list where one could join.
Also picked up some broke links refering to CNCF-SIGs instead of CNCF-TAGS