### PR TITLE
Clean-up: Update settings.yml 

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,25 +11,5 @@ repository:
   homepage: https://cncf.io/projects
   
   # Collaborators: give specific users access to this repository.
-  # see /governance/roles.md for details on write access policy
-  # note that the permissions below may provide wider access than needed for
-  # a specific role, and we trust these individuals to act according to their
-  # role. If there are questions, please contact one of the chairs.
-collaborators:
-  # TOC Liasons
-  - username: mauilion
-    permission: admin
-    
-  - username: rochaporto
-    permission: admin
-
-  # SIG Chairs 
-  - username: leecalcote
-    permission: admin
-
-  - username: linsun
-    permission: admin
-
-  - username: ZackButcher
-    permission: admin  
-    
+  # Note that the permissions are controlled in the https://github.com/cncf/people/blob/main/config.yaml file
+  # Please create a PR in the https://github.com/cncf/people/ repo to change user access


### PR DESCRIPTION
People and permissions have been moved to the [cncf/people/config.yml file](https://github.com/cncf/people/blob/main/config.yaml) making permissions in the local settings.yml file redundant.

Proposed updates:

- [x]  Remove the people from the local settings.yml
- [x]  Add a link in the setting.yml to the [cncf/people/config.yml file](https://github.com/cncf/people/blob/main/config.yaml#L847-L860) for clarity